### PR TITLE
Require authenticated Kirby user for help file route

### DIFF
--- a/index.php
+++ b/index.php
@@ -38,6 +38,10 @@ Kirby::plugin('medienbaecker/help-view', [
 				'pattern' => 'help/file/(:all)',
 				'auth'    => false,
 				'action'  => function (string $path): Response {
+					if (!kirby()->user()) {
+						return new Response('Unauthorized', 'text/plain', 401);
+					}
+
 					$root = Help::root();
 					$rootReal = realpath($root);
 


### PR DESCRIPTION
Hi Thomas, 

thank you for this great plugin :) 

Regarding your note, that the files are served via an API route without authentication... We could easily check if there is an current panel-session and return 401 if not. Might be a nice little addition.

Let me know what you think.